### PR TITLE
Feature/#4 회원가입 및 로그인 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,11 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/org/example/capstonedesign1/CapstoneDesign1Application.java
+++ b/src/main/java/org/example/capstonedesign1/CapstoneDesign1Application.java
@@ -2,8 +2,10 @@ package org.example.capstonedesign1;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class CapstoneDesign1Application {
 
     public static void main(String[] args) {

--- a/src/main/java/org/example/capstonedesign1/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/example/capstonedesign1/domain/auth/controller/AuthController.java
@@ -1,0 +1,53 @@
+package org.example.capstonedesign1.domain.auth.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.RequiredArgsConstructor;
+import org.example.capstonedesign1.domain.auth.dto.request.LoginRequest;
+import org.example.capstonedesign1.domain.auth.dto.request.SignUpCompleteRequest;
+import org.example.capstonedesign1.domain.auth.dto.request.SignUpRequest;
+import org.example.capstonedesign1.domain.auth.dto.response.SignUpResponse;
+import org.example.capstonedesign1.domain.auth.service.AuthService;
+import org.example.capstonedesign1.domain.user.entity.User;
+import org.example.capstonedesign1.global.dto.ResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+    
+    private final AuthService authService;
+
+    @Operation(
+            summary = "로컬 회원가입 API",
+            description = "이메일과 비밀번호, 프로필 정보를 사용하여 새로운 회원을 등록."
+    )
+    @PostMapping("/sign-up")
+    public ResponseEntity<ResponseDto<SignUpResponse>> signUp(@RequestBody SignUpRequest request){
+        SignUpResponse response = authService.signUp(request);
+
+        return new ResponseEntity<>(
+                ResponseDto.res(HttpStatus.CREATED, "회원가입 성공", response), HttpStatus.CREATED);
+    }
+
+    @Operation(
+            summary = "로컬 로그인 API",
+            description = "이메일과 비밀번호를 로컬 로그인"
+    )
+    @PostMapping("/login")
+    public ResponseEntity<ResponseDto<Void>> login(@RequestBody SignUpCompleteRequest request){
+//        authService.signUpComplete();
+
+        return new ResponseEntity<>(
+                ResponseDto.res(HttpStatus.CREATED, "회원가입 완료 성공"), HttpStatus.CREATED);
+    }
+
+
+
+}

--- a/src/main/java/org/example/capstonedesign1/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/example/capstonedesign1/domain/auth/controller/AuthController.java
@@ -1,17 +1,18 @@
 package org.example.capstonedesign1.domain.auth.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.capstonedesign1.domain.auth.dto.request.LoginRequest;
 import org.example.capstonedesign1.domain.auth.dto.request.SignUpCompleteRequest;
 import org.example.capstonedesign1.domain.auth.dto.request.SignUpRequest;
-import org.example.capstonedesign1.domain.auth.dto.response.SignUpResponse;
+import org.example.capstonedesign1.domain.auth.dto.response.AuthenticationResponse;
+import org.example.capstonedesign1.domain.auth.security.CustomUserDetails;
 import org.example.capstonedesign1.domain.auth.service.AuthService;
-import org.example.capstonedesign1.domain.user.entity.User;
 import org.example.capstonedesign1.global.dto.ResponseDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,31 +22,41 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/auth")
 public class AuthController {
-    
     private final AuthService authService;
 
     @Operation(
             summary = "로컬 회원가입 API",
-            description = "이메일과 비밀번호, 프로필 정보를 사용하여 새로운 회원을 등록."
+            description = "이메일과 비밀번호를 사용하여 새로운 회원을 등록"
     )
     @PostMapping("/sign-up")
-    public ResponseEntity<ResponseDto<SignUpResponse>> signUp(@RequestBody SignUpRequest request){
-        SignUpResponse response = authService.signUp(request);
+    public ResponseEntity<ResponseDto<AuthenticationResponse>> signUp(@RequestBody @Valid SignUpRequest request){
+        AuthenticationResponse response = authService.signUp(request);
 
         return new ResponseEntity<>(
                 ResponseDto.res(HttpStatus.CREATED, "회원가입 성공", response), HttpStatus.CREATED);
     }
 
     @Operation(
-            summary = "로컬 로그인 API",
-            description = "이메일과 비밀번호를 로컬 로그인"
+            summary = "회원가입 완료 API",
+            description = "프로필 정보를 입력받아 회원가입 완료"
+    )
+    @PostMapping("/sign-up/complete")
+    public ResponseEntity<ResponseDto<Void>> SignUpComplete(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                                            @RequestBody @Valid SignUpCompleteRequest request){
+        authService.signUpComplete(customUserDetails.getUser(), request);
+        return new ResponseEntity<>(
+                ResponseDto.res(HttpStatus.CREATED, "회원가입 완료 성공"), HttpStatus.OK);
+    }
+
+    @Operation(
+            summary = "로그인 API",
+            description = "이메일과 비밀번호를 사용하여 로그인"
     )
     @PostMapping("/login")
-    public ResponseEntity<ResponseDto<Void>> login(@RequestBody SignUpCompleteRequest request){
-//        authService.signUpComplete();
+    public ResponseEntity<ResponseDto<Void>> login(@RequestBody @Valid LoginRequest request){
 
         return new ResponseEntity<>(
-                ResponseDto.res(HttpStatus.CREATED, "회원가입 완료 성공"), HttpStatus.CREATED);
+                ResponseDto.res(HttpStatus.CREATED, "로그인 성공"), HttpStatus.CREATED);
     }
 
 

--- a/src/main/java/org/example/capstonedesign1/domain/auth/dto/request/LoginRequest.java
+++ b/src/main/java/org/example/capstonedesign1/domain/auth/dto/request/LoginRequest.java
@@ -1,0 +1,17 @@
+package org.example.capstonedesign1.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequest {
+    @Email(message = "올바르지 않은 이메일 형식입니다.")
+    @NotBlank(message = "이메일은 필수입니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private String password;
+}

--- a/src/main/java/org/example/capstonedesign1/domain/auth/dto/request/SignUpCompleteRequest.java
+++ b/src/main/java/org/example/capstonedesign1/domain/auth/dto/request/SignUpCompleteRequest.java
@@ -1,0 +1,53 @@
+package org.example.capstonedesign1.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.capstonedesign1.domain.user.entity.enums.Gender;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@Getter
+public class SignUpCompleteRequest {
+
+    @NotBlank
+    private String nickname;
+
+    @Schema(
+            description = "생년월일",
+            example = "1990-01-01",
+            type = "string"
+    )
+    @NotNull(message = "생년월일은 필수입니다.")
+    @Past
+    private LocalDate birthDate;
+
+    @Schema(
+            description = "성별",
+            allowableValues = {"MALE", "FEMALE"}
+    )
+    @NotNull(message = "성별은 필수입니다.")
+    private Gender gender;
+
+    @Schema(
+            description = "자산. 원 단위",
+            minimum = "0",
+            maximum = "10000000000000"
+    )
+    @NotNull(message = "자산값은 필수입니다.")
+    @Min(value = 0, message = "자산은 0 이상이어야 합니다.")
+    @Max(value = 10_000_000_000_000L, message = "자산은 1경 원을 넘을 수 없습니다.")
+    private Long asset;
+
+    @Schema(
+            description = "월 수익. 원 단위",
+            minimum = "0",
+            maximum = "2000000000"
+    )
+    @Min(value = 0, message = "월 수익은 0 이상이어야 합니다.")
+    @Max(value = 2_000_000_000, message = "월 수익은 20억 원을 넘을 수 없습니다.")
+    private Integer salary;
+
+}

--- a/src/main/java/org/example/capstonedesign1/domain/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/org/example/capstonedesign1/domain/auth/dto/request/SignUpRequest.java
@@ -1,0 +1,16 @@
+package org.example.capstonedesign1.domain.auth.dto.request;
+
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SignUpRequest {
+    @Email(message = "올바르지 않은 이메일 형식입니다.")
+    @NotBlank(message = "이메일은 필수입니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private String password;
+}

--- a/src/main/java/org/example/capstonedesign1/domain/auth/dto/response/AuthenticationResponse.java
+++ b/src/main/java/org/example/capstonedesign1/domain/auth/dto/response/AuthenticationResponse.java
@@ -1,0 +1,5 @@
+package org.example.capstonedesign1.domain.auth.dto.response;
+
+
+public record AuthenticationResponse(String accessToken, boolean registerCompleted) {
+}

--- a/src/main/java/org/example/capstonedesign1/domain/auth/dto/response/SignUpResponse.java
+++ b/src/main/java/org/example/capstonedesign1/domain/auth/dto/response/SignUpResponse.java
@@ -1,5 +1,0 @@
-package org.example.capstonedesign1.domain.auth.dto.response;
-
-
-public record SignUpResponse(String accessToken, boolean registerCompleted) {
-}

--- a/src/main/java/org/example/capstonedesign1/domain/auth/dto/response/SignUpResponse.java
+++ b/src/main/java/org/example/capstonedesign1/domain/auth/dto/response/SignUpResponse.java
@@ -1,0 +1,5 @@
+package org.example.capstonedesign1.domain.auth.dto.response;
+
+
+public record SignUpResponse(String accessToken, boolean registerCompleted) {
+}

--- a/src/main/java/org/example/capstonedesign1/domain/auth/jwt/BearerEncoder.java
+++ b/src/main/java/org/example/capstonedesign1/domain/auth/jwt/BearerEncoder.java
@@ -1,0 +1,21 @@
+package org.example.capstonedesign1.domain.auth.jwt;
+
+import org.springframework.stereotype.Component;
+
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+
+@Component
+public class BearerEncoder {
+    private static final String TOKEN_TYPE = "Bearer ";
+
+    public static String encode(String token) {
+        return URLEncoder.encode(TOKEN_TYPE + token, StandardCharsets.UTF_8).replaceAll("\\+", "%20");
+    }
+
+    public static String decode(String encodedToken) {
+        return URLDecoder.decode(encodedToken, StandardCharsets.UTF_8).replace("Bearer ", "");
+    }
+}

--- a/src/main/java/org/example/capstonedesign1/domain/auth/jwt/JwtUtil.java
+++ b/src/main/java/org/example/capstonedesign1/domain/auth/jwt/JwtUtil.java
@@ -1,0 +1,54 @@
+package org.example.capstonedesign1.domain.auth.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+    private static final String TOKEN_TYPE = "Bearer ";
+    private final SecretKey secretKey;
+    private final long validityInMilliseconds;
+
+    public JwtUtil(@Value("${jwt.access-token.secret}") final String secretKey,
+                   @Value("${jwt.access-token.expired-time}") final long validityInMilliseconds){
+        this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        this.validityInMilliseconds = validityInMilliseconds;
+    }
+
+    public String issueAccessToken(String subject){
+        String accessToken = createAccessToken(subject);
+        return encodeJwtToken(accessToken);
+    }
+
+    public String createAccessToken(String subject){
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + validityInMilliseconds);
+        return Jwts.builder()
+                .subject(subject)
+                .issuedAt(now)
+                .expiration(validity)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    boolean isExpired(String token){
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token)
+                .getPayload()
+                .getExpiration()
+                .before(new Date());
+    }
+
+    public String encodeJwtToken(String token){
+        String bearerToken = TOKEN_TYPE + token;
+        return URLEncoder.encode(bearerToken, StandardCharsets.UTF_8).replaceAll("\\+", "%20");
+    }
+
+}

--- a/src/main/java/org/example/capstonedesign1/domain/auth/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/org/example/capstonedesign1/domain/auth/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,33 @@
+package org.example.capstonedesign1.domain.auth.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.example.capstonedesign1.global.dto.ErrorResponseDto;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        response.getWriter().write(objectMapper.writeValueAsString(
+                ErrorResponseDto.res(String.valueOf(HttpServletResponse.SC_UNAUTHORIZED), authException)));
+    }
+
+}

--- a/src/main/java/org/example/capstonedesign1/domain/auth/security/CustomUserDetails.java
+++ b/src/main/java/org/example/capstonedesign1/domain/auth/security/CustomUserDetails.java
@@ -1,0 +1,61 @@
+package org.example.capstonedesign1.domain.auth.security;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.example.capstonedesign1.domain.user.entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+
+        collection.add(new GrantedAuthority() {
+            @Override
+            public String getAuthority() {
+                return user.getRole().name();
+            }
+        });
+
+        return collection;
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/org/example/capstonedesign1/domain/auth/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/capstonedesign1/domain/auth/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,111 @@
+package org.example.capstonedesign1.domain.auth.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.capstonedesign1.domain.auth.jwt.BearerEncoder;
+import org.example.capstonedesign1.domain.auth.jwt.JwtProvider;
+import org.example.capstonedesign1.domain.auth.security.CustomUserDetails;
+import org.example.capstonedesign1.domain.user.entity.User;
+import org.example.capstonedesign1.domain.user.service.UserService;
+import org.example.capstonedesign1.global.dto.ErrorResponseDto;
+import org.example.capstonedesign1.global.exception.CustomException;
+import org.example.capstonedesign1.global.exception.UnAuthenticationException;
+import org.example.capstonedesign1.global.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final UserService userService;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+//        String requestUri =  request.getRequestURI();
+//        return (requestUri.startsWith("/auth/sign-up")
+//                && !requestUri.startsWith("/auth/sign-up/complete"))
+//                || requestUri.startsWith("/auth/login")
+//                || requestUri.startsWith("/swagger-ui")
+//                || requestUri.startsWith("/v3/api-docs");
+
+        String requestUri =  request.getRequestURI();
+        boolean skip = (requestUri.startsWith("/auth/sign-up")
+                && !requestUri.startsWith("/auth/sign-up/complete"))
+                || requestUri.startsWith("/auth/login")
+                || requestUri.startsWith("/swagger-ui")
+                || requestUri.startsWith("/v3/api-docs");
+
+        log.info("{}, {}", requestUri, String.valueOf(skip));
+        return skip;
+    }
+
+    /**
+     * entryPoint를 사용하면 응답 통일 시 사용하던 errorCode의 customStatus나 customMessage를 사용할 수 없으므로 필터에서 예외를 직접 처리
+     * @param request
+     * @param response
+     * @param filterChain
+     * @throws ServletException
+     * @throws IOException
+     */
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            UUID userId = UUID.fromString(parsePayload(request, response));
+            User user = userService.findById(userId);
+            CustomUserDetails customUserDetails = new CustomUserDetails(user);
+
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                    customUserDetails,
+                    null,
+                    List.of(new SimpleGrantedAuthority(user.getRole().toString()))
+            );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            filterChain.doFilter(request, response);
+        }catch (ExpiredJwtException expiredJwtException){
+            sendErrorResponse(response, new UnAuthenticationException(ErrorCode.EXPIRED_JWT_TOKEN));
+        }catch (Exception e){
+            sendErrorResponse(response, new UnAuthenticationException(ErrorCode.INVALID_JWT_TOKEN));
+        }
+    }
+
+    /**
+     * @return jwt 토큰에서 파싱한 payload 반환
+     */
+    private String parsePayload(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        String bearerToken = request.getHeader("Authorization");
+        String tokenValue = BearerEncoder.decode(bearerToken);
+        return jwtProvider.parsePayload(tokenValue);
+    }
+
+    private void sendErrorResponse(HttpServletResponse response,
+                                   CustomException customException) throws IOException {
+        HttpStatus httpStatus = HttpStatus.valueOf(customException.getErrorCode().getStatus().substring(0,3));
+
+        response.setStatus(httpStatus.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        response.getWriter().write(objectMapper.writeValueAsString(
+                ErrorResponseDto.res(customException)));
+    }
+}

--- a/src/main/java/org/example/capstonedesign1/domain/auth/security/filter/JwtLoginFilter.java
+++ b/src/main/java/org/example/capstonedesign1/domain/auth/security/filter/JwtLoginFilter.java
@@ -1,0 +1,91 @@
+package org.example.capstonedesign1.domain.auth.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.capstonedesign1.domain.auth.dto.request.LoginRequest;
+import org.example.capstonedesign1.domain.auth.dto.response.AuthenticationResponse;
+import org.example.capstonedesign1.domain.auth.security.CustomUserDetails;
+import org.example.capstonedesign1.domain.auth.service.AuthService;
+import org.example.capstonedesign1.domain.auth.service.TokenService;
+import org.example.capstonedesign1.domain.user.entity.User;
+import org.example.capstonedesign1.domain.user.service.UserService;
+import org.example.capstonedesign1.global.dto.ErrorResponseDto;
+import org.example.capstonedesign1.global.dto.ResponseDto;
+import org.example.capstonedesign1.global.exception.BadRequestException;
+import org.example.capstonedesign1.global.exception.UnAuthenticationException;
+import org.example.capstonedesign1.global.exception.code.ErrorCode;
+import org.springframework.context.ApplicationContext;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtLoginFilter extends UsernamePasswordAuthenticationFilter {
+    private final AuthenticationManager authenticationManager;
+    private final TokenService tokenService;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
+            throws AuthenticationException {
+        LoginRequest loginRequest = parseLoginRequest(request);
+
+        UsernamePasswordAuthenticationToken authenticationToken =
+                new UsernamePasswordAuthenticationToken(loginRequest.getEmail(), loginRequest.getPassword());
+
+        return authenticationManager.authenticate(authenticationToken);
+    }
+
+    @Override
+    public void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain,
+                                         Authentication authResult) throws IOException, ServletException {
+        CustomUserDetails customUserDetails = (CustomUserDetails) authResult.getPrincipal();
+
+        User user = customUserDetails.getUser();
+
+        AuthenticationResponse authenticationResponse = new AuthenticationResponse(
+                tokenService.issueAccessToken(user.getId().toString()), user.isRegisterCompleted());
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(
+                ResponseDto.res(HttpStatus.OK, "로그인 성공", authenticationResponse)));
+    }
+
+    @Override
+    public void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response,
+                                           AuthenticationException failed) throws IOException, ServletException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        String jsonErrorResponse = objectMapper.writeValueAsString(
+                ErrorResponseDto.res(new UnAuthenticationException(ErrorCode.USER_UNAUTHORIZED)));
+        response.getWriter().write(jsonErrorResponse);
+    }
+
+
+    private LoginRequest parseLoginRequest(HttpServletRequest request){
+        try {
+            return objectMapper.readValue(request.getInputStream(), LoginRequest.class);
+        } catch (IOException e) {
+            log.error("errorMessage: {}", e.getMessage());
+            throw new BadRequestException(ErrorCode.JSON_PARSE_ERROR, e.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/org/example/capstonedesign1/domain/auth/security/service/CustomUserDetailsService.java
+++ b/src/main/java/org/example/capstonedesign1/domain/auth/security/service/CustomUserDetailsService.java
@@ -1,0 +1,25 @@
+package org.example.capstonedesign1.domain.auth.security.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.capstonedesign1.domain.auth.security.CustomUserDetails;
+import org.example.capstonedesign1.domain.user.entity.User;
+import org.example.capstonedesign1.domain.user.repository.UserRepository;
+import org.example.capstonedesign1.domain.user.service.UserService;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserService userService;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userService.findByEmail(username);
+        // 추후 OAuth 추가 시 인증 로직 추가.
+        return new CustomUserDetails(user);
+    }
+}

--- a/src/main/java/org/example/capstonedesign1/domain/auth/service/AuthService.java
+++ b/src/main/java/org/example/capstonedesign1/domain/auth/service/AuthService.java
@@ -1,0 +1,44 @@
+package org.example.capstonedesign1.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.antlr.v4.runtime.Token;
+import org.example.capstonedesign1.domain.auth.dto.request.SignUpCompleteRequest;
+import org.example.capstonedesign1.domain.auth.dto.request.SignUpRequest;
+import org.example.capstonedesign1.domain.auth.dto.response.SignUpResponse;
+import org.example.capstonedesign1.domain.auth.jwt.JwtUtil;
+import org.example.capstonedesign1.domain.user.entity.Profile;
+import org.example.capstonedesign1.domain.user.entity.User;
+import org.example.capstonedesign1.domain.user.entity.enums.Status;
+import org.example.capstonedesign1.domain.user.repository.UserRepository;
+import org.example.capstonedesign1.global.exception.ConflictException;
+import org.example.capstonedesign1.global.exception.code.ErrorCode;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final UserRepository userRepository;
+    private final TokenService tokenService;
+
+
+    /**
+     * id, pw 회원가입
+     * @param request
+     */
+    public SignUpResponse signUp(SignUpRequest request){
+        if(userRepository.existsByEmail(request.getEmail())){
+            throw new ConflictException(ErrorCode.CONFLICT_EMAIL);
+        }
+
+        User user = new User(request.getEmail(), passwordEncoder.encode(request.getPassword()));
+        userRepository.save(user);
+        String accessToken = tokenService.issueAccessToken(user.getId().toString());
+        return new SignUpResponse(accessToken, user.isRegisterCompleted());
+    }
+
+
+}

--- a/src/main/java/org/example/capstonedesign1/domain/auth/service/AuthService.java
+++ b/src/main/java/org/example/capstonedesign1/domain/auth/service/AuthService.java
@@ -40,5 +40,18 @@ public class AuthService {
         return new SignUpResponse(accessToken, user.isRegisterCompleted());
     }
 
-
+    /**
+     * 회원 정보 기입을 통해 회원가입 완료
+     * @param user
+     * @param request
+     */
+    @Transactional
+    public void signUpComplete(User user, SignUpCompleteRequest request){
+        if(user.isRegisterCompleted()){
+           throw new ConflictException(ErrorCode.ALREADY_REGISTER_COMPLETED);
+        }
+        Profile profile = Profile.from(request);
+        user.signUpComplete(profile);
+        userRepository.save(user);
+    }
 }

--- a/src/main/java/org/example/capstonedesign1/domain/auth/service/AuthService.java
+++ b/src/main/java/org/example/capstonedesign1/domain/auth/service/AuthService.java
@@ -1,20 +1,17 @@
 package org.example.capstonedesign1.domain.auth.service;
 
 import lombok.RequiredArgsConstructor;
-import org.antlr.v4.runtime.Token;
 import org.example.capstonedesign1.domain.auth.dto.request.SignUpCompleteRequest;
 import org.example.capstonedesign1.domain.auth.dto.request.SignUpRequest;
-import org.example.capstonedesign1.domain.auth.dto.response.SignUpResponse;
-import org.example.capstonedesign1.domain.auth.jwt.JwtUtil;
+import org.example.capstonedesign1.domain.auth.dto.response.AuthenticationResponse;
 import org.example.capstonedesign1.domain.user.entity.Profile;
 import org.example.capstonedesign1.domain.user.entity.User;
-import org.example.capstonedesign1.domain.user.entity.enums.Status;
 import org.example.capstonedesign1.domain.user.repository.UserRepository;
 import org.example.capstonedesign1.global.exception.ConflictException;
 import org.example.capstonedesign1.global.exception.code.ErrorCode;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -29,7 +26,7 @@ public class AuthService {
      * id, pw 회원가입
      * @param request
      */
-    public SignUpResponse signUp(SignUpRequest request){
+    public AuthenticationResponse signUp(SignUpRequest request){
         if(userRepository.existsByEmail(request.getEmail())){
             throw new ConflictException(ErrorCode.CONFLICT_EMAIL);
         }
@@ -37,7 +34,7 @@ public class AuthService {
         User user = new User(request.getEmail(), passwordEncoder.encode(request.getPassword()));
         userRepository.save(user);
         String accessToken = tokenService.issueAccessToken(user.getId().toString());
-        return new SignUpResponse(accessToken, user.isRegisterCompleted());
+        return new AuthenticationResponse(accessToken, user.isRegisterCompleted());
     }
 
     /**

--- a/src/main/java/org/example/capstonedesign1/domain/auth/service/TokenService.java
+++ b/src/main/java/org/example/capstonedesign1/domain/auth/service/TokenService.java
@@ -1,0 +1,16 @@
+package org.example.capstonedesign1.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.capstonedesign1.domain.auth.jwt.JwtUtil;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+    private final JwtUtil jwtUtil;
+
+    public String issueAccessToken(String subject){
+        return jwtUtil.issueAccessToken(subject);
+    }
+
+}

--- a/src/main/java/org/example/capstonedesign1/domain/auth/service/TokenService.java
+++ b/src/main/java/org/example/capstonedesign1/domain/auth/service/TokenService.java
@@ -1,16 +1,15 @@
 package org.example.capstonedesign1.domain.auth.service;
 
 import lombok.RequiredArgsConstructor;
-import org.example.capstonedesign1.domain.auth.jwt.JwtUtil;
+import org.example.capstonedesign1.domain.auth.jwt.JwtProvider;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class TokenService {
-    private final JwtUtil jwtUtil;
-
+    private final JwtProvider jwtProvider;
     public String issueAccessToken(String subject){
-        return jwtUtil.issueAccessToken(subject);
+        return jwtProvider.issueAccessToken(subject);
     }
 
 }

--- a/src/main/java/org/example/capstonedesign1/domain/user/entity/Profile.java
+++ b/src/main/java/org/example/capstonedesign1/domain/user/entity/Profile.java
@@ -1,0 +1,24 @@
+package org.example.capstonedesign1.domain.user.entity;
+
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import org.example.capstonedesign1.domain.user.entity.enums.Gender;
+import org.example.capstonedesign1.domain.user.entity.enums.Status;
+
+import java.time.LocalDate;
+
+@Embeddable
+public class Profile {
+    private String nickname;
+    private LocalDate birthDate;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    private Long asset;
+    private Integer salary;
+}

--- a/src/main/java/org/example/capstonedesign1/domain/user/entity/Profile.java
+++ b/src/main/java/org/example/capstonedesign1/domain/user/entity/Profile.java
@@ -4,21 +4,40 @@ package org.example.capstonedesign1.domain.user.entity;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.example.capstonedesign1.domain.auth.dto.request.SignUpCompleteRequest;
 import org.example.capstonedesign1.domain.user.entity.enums.Gender;
 import org.example.capstonedesign1.domain.user.entity.enums.Status;
 
 import java.time.LocalDate;
 
 @Embeddable
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Profile {
     private String nickname;
     private LocalDate birthDate;
+    private Long asset;
+    private Integer salary;
 
     @Enumerated(EnumType.STRING)
     private Gender gender;
     @Enumerated(EnumType.STRING)
     private Status status;
 
-    private Long asset;
-    private Integer salary;
+    public static Profile from(SignUpCompleteRequest request){
+        return Profile.builder()
+                .nickname(request.getNickname())
+                .gender(request.getGender())
+                .salary(request.getSalary())
+                .birthDate(request.getBirthDate())
+                .asset(request.getAsset())
+                .status(Status.ACTIVE)
+                .build();
+    }
+
 }

--- a/src/main/java/org/example/capstonedesign1/domain/user/entity/User.java
+++ b/src/main/java/org/example/capstonedesign1/domain/user/entity/User.java
@@ -1,20 +1,18 @@
 package org.example.capstonedesign1.domain.user.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
+import org.example.capstonedesign1.domain.user.entity.enums.Role;
 import org.example.capstonedesign1.global.common.BaseEntity;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
 public class User extends BaseEntity {
 
-    @Column(unique = true)
+    @Column(unique = true, nullable = false)
     private String email;
+    @Column(nullable = false)
     private String password;
 
     @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
@@ -27,5 +25,15 @@ public class User extends BaseEntity {
     @Embedded
     private Profile profile;
 
+    public User(String email, String password){
+        this.email = email;
+        this.password = password;
+        this.registerCompleted = false;
+    }
+
+    public void signUpComplete(Profile profile){
+        this.profile = profile;
+        this.registerCompleted = true;
+    }
 
 }

--- a/src/main/java/org/example/capstonedesign1/domain/user/entity/User.java
+++ b/src/main/java/org/example/capstonedesign1/domain/user/entity/User.java
@@ -1,0 +1,24 @@
+package org.example.capstonedesign1.domain.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.capstonedesign1.global.common.BaseEntity;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Entity
+public class User extends BaseEntity {
+
+    @Column(unique = true)
+    private String email;
+    private String password;
+
+    @Embedded
+    private Profile profile;
+
+
+}

--- a/src/main/java/org/example/capstonedesign1/domain/user/entity/User.java
+++ b/src/main/java/org/example/capstonedesign1/domain/user/entity/User.java
@@ -17,6 +17,13 @@ public class User extends BaseEntity {
     private String email;
     private String password;
 
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private boolean registerCompleted = false;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Role role = Role.ROLE_USER;
+
     @Embedded
     private Profile profile;
 

--- a/src/main/java/org/example/capstonedesign1/domain/user/entity/enums/Gender.java
+++ b/src/main/java/org/example/capstonedesign1/domain/user/entity/enums/Gender.java
@@ -1,0 +1,15 @@
+package org.example.capstonedesign1.domain.user.entity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Gender {
+    MALE("남성"),
+    FEMALE("여성")
+    ;
+
+    private final String description;
+
+}

--- a/src/main/java/org/example/capstonedesign1/domain/user/entity/enums/Role.java
+++ b/src/main/java/org/example/capstonedesign1/domain/user/entity/enums/Role.java
@@ -1,0 +1,5 @@
+package org.example.capstonedesign1.domain.user.entity.enums;
+
+public enum Role {
+    ROLE_USER, ROLE_ADMIN
+}

--- a/src/main/java/org/example/capstonedesign1/domain/user/entity/enums/Status.java
+++ b/src/main/java/org/example/capstonedesign1/domain/user/entity/enums/Status.java
@@ -1,0 +1,20 @@
+package org.example.capstonedesign1.domain.user.entity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+
+@Getter
+@AllArgsConstructor
+public enum Status {
+
+    ACTIVE("활성화"),
+    INACTIVE("비활성화"),
+    DELETED("삭제"),
+    SIGNUP_INCOMPLETE("회원가입 미완료")
+    ;
+
+    private final String description;
+
+}
+

--- a/src/main/java/org/example/capstonedesign1/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/capstonedesign1/domain/user/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package org.example.capstonedesign1.domain.user.repository;
+
+import org.example.capstonedesign1.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, UUID> {
+    boolean existsByEmail(String email);
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/org/example/capstonedesign1/domain/user/service/UserService.java
+++ b/src/main/java/org/example/capstonedesign1/domain/user/service/UserService.java
@@ -1,0 +1,26 @@
+package org.example.capstonedesign1.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.capstonedesign1.domain.user.entity.User;
+import org.example.capstonedesign1.domain.user.repository.UserRepository;
+import org.example.capstonedesign1.global.exception.NotFoundException;
+import org.example.capstonedesign1.global.exception.code.ErrorCode;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    public User findByEmail(String email){
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    public User findById(UUID id){
+        return userRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/example/capstonedesign1/global/common/BaseEntity.java
+++ b/src/main/java/org/example/capstonedesign1/global/common/BaseEntity.java
@@ -1,0 +1,27 @@
+package org.example.capstonedesign1.global.common;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "uuid2")
+    @Column(updatable = false, unique = true, nullable = false)
+    private UUID id;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/example/capstonedesign1/global/config/ModuleConfig.java
+++ b/src/main/java/org/example/capstonedesign1/global/config/ModuleConfig.java
@@ -1,0 +1,19 @@
+package org.example.capstonedesign1.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ModuleConfig {
+
+    @Bean
+    public ObjectMapper objectMapper(){
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule()); // JavaTimeModule 등록
+        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false); // 타임스탬프 비활성화
+        return objectMapper;
+    }
+}

--- a/src/main/java/org/example/capstonedesign1/global/config/SecurityConfig.java
+++ b/src/main/java/org/example/capstonedesign1/global/config/SecurityConfig.java
@@ -1,18 +1,33 @@
 package org.example.capstonedesign1.global.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.example.capstonedesign1.domain.auth.jwt.JwtProvider;
+import org.example.capstonedesign1.domain.auth.security.CustomAuthenticationEntryPoint;
+import org.example.capstonedesign1.domain.auth.security.filter.JwtAuthenticationFilter;
+import org.example.capstonedesign1.domain.auth.security.filter.JwtLoginFilter;
+import org.example.capstonedesign1.domain.auth.service.TokenService;
+import org.example.capstonedesign1.domain.user.service.UserService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+    private final AuthenticationConfiguration authenticationConfiguration;
+    private final TokenService tokenService;
+    private final ObjectMapper objectMapper;
+    private final JwtProvider jwtProvider;
+    private final UserService userService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
@@ -28,11 +43,44 @@ public class SecurityConfig {
                         .anyRequest().authenticated())
                 ;
 
+        http
+                .addFilterAt(getJwtLoginFilter(), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling(exceptions ->
+                        exceptions.authenticationEntryPoint(customAuthenticationEntryPoint()))
+                ;
+
+
         return http.build();
+    }
+
+    @Bean
+    public CustomAuthenticationEntryPoint customAuthenticationEntryPoint(){
+        return new CustomAuthenticationEntryPoint(objectMapper);
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter(){
+        return new JwtAuthenticationFilter(jwtProvider, userService, objectMapper);
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
     }
 
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder(){
         return new BCryptPasswordEncoder();
+    }
+
+    private JwtLoginFilter getJwtLoginFilter() throws Exception {
+
+        JwtLoginFilter jwtLoginFilter = new JwtLoginFilter(
+                authenticationManager(authenticationConfiguration),
+                tokenService,
+                objectMapper);
+        jwtLoginFilter.setFilterProcessesUrl("/auth/login");
+        return jwtLoginFilter;
     }
 }

--- a/src/main/java/org/example/capstonedesign1/global/config/SecurityConfig.java
+++ b/src/main/java/org/example/capstonedesign1/global/config/SecurityConfig.java
@@ -1,0 +1,38 @@
+package org.example.capstonedesign1.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
+        http
+                .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
+                        .requestMatchers("/auth/sign-up", "/auth/login").permitAll()
+                        .anyRequest().authenticated())
+                ;
+
+        return http.build();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/org/example/capstonedesign1/global/config/SwaggerConfig.java
+++ b/src/main/java/org/example/capstonedesign1/global/config/SwaggerConfig.java
@@ -1,0 +1,42 @@
+package org.example.capstonedesign1.global.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        servers = {
+                @Server(url = "http://localhost:8080", description = "local 서버")
+        }
+)
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        String jwtSchemeName = "Authorization";
+        // API 요청헤더에 인증정보 포함
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+        // SecuritySchemes 등록
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("Bearer")
+                        .bearerFormat("JWT"));
+
+        return new OpenAPI()
+                .addSecurityItem(securityRequirement)
+                .components(components)
+                .info(new Info()
+                        .title("MPT API Documentation")
+                        .description("MPT - 25-1학기 캡스톤 디자인1 api 명세서")
+                        .version("1.0.0"));
+    }
+}

--- a/src/main/java/org/example/capstonedesign1/global/dto/ErrorResponseDto.java
+++ b/src/main/java/org/example/capstonedesign1/global/dto/ErrorResponseDto.java
@@ -2,11 +2,13 @@ package org.example.capstonedesign1.global.dto;
 
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.example.capstonedesign1.global.exception.CustomException;
 
 import java.time.LocalDateTime;
 
+@Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class ErrorResponseDto {
     private final String errorCode;
@@ -29,6 +31,5 @@ public class ErrorResponseDto {
                 LocalDateTime.now(),
                 null);
     }
-
 
 }

--- a/src/main/java/org/example/capstonedesign1/global/dto/ErrorResponseDto.java
+++ b/src/main/java/org/example/capstonedesign1/global/dto/ErrorResponseDto.java
@@ -1,0 +1,34 @@
+package org.example.capstonedesign1.global.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.example.capstonedesign1.global.exception.CustomException;
+
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ErrorResponseDto {
+    private final String errorCode;
+    private final String message;
+    private final LocalDateTime timeStamp;
+    private final String detail;
+
+    public static ErrorResponseDto res(final CustomException customException){
+        return new ErrorResponseDto(
+                customException.getErrorCode().getStatus(),
+                customException.getErrorCode().getMessage(),
+                LocalDateTime.now(),
+                customException.getDetail());
+    }
+
+    public static ErrorResponseDto res(final String errorCode, final Exception e){
+        return new ErrorResponseDto(
+                errorCode,
+                e.getMessage(),
+                LocalDateTime.now(),
+                null);
+    }
+
+
+}

--- a/src/main/java/org/example/capstonedesign1/global/dto/ErrorResponseDto.java
+++ b/src/main/java/org/example/capstonedesign1/global/dto/ErrorResponseDto.java
@@ -1,8 +1,9 @@
 package org.example.capstonedesign1.global.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.example.capstonedesign1.global.exception.CustomException;
 
@@ -10,10 +11,13 @@ import java.time.LocalDateTime;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonPropertyOrder({"errorCode", "message", "timeStamp", "detail"})
 public class ErrorResponseDto {
     private final String errorCode;
     private final String message;
     private final LocalDateTime timeStamp;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private final String detail;
 
     public static ErrorResponseDto res(final CustomException customException){

--- a/src/main/java/org/example/capstonedesign1/global/dto/ResponseDto.java
+++ b/src/main/java/org/example/capstonedesign1/global/dto/ResponseDto.java
@@ -1,0 +1,33 @@
+package org.example.capstonedesign1.global.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@JsonPropertyOrder({"code", "message", "timestamp", "data"})
+public class ResponseDto<T> {
+
+    private final String statusCode;
+    private final String message;
+    private final LocalDateTime timeStamp;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final T data;
+
+
+    public static <T> ResponseDto<T> res(HttpStatus status, String message){
+        return new ResponseDto<>(String.valueOf(status), message, LocalDateTime.now(), null);
+    }
+
+    public static <T> ResponseDto<T> res(HttpStatus status, String message, T data){
+        return new ResponseDto<>(String.valueOf(status), message, LocalDateTime.now(), data);
+    }
+}

--- a/src/main/java/org/example/capstonedesign1/global/dto/ResponseDto.java
+++ b/src/main/java/org/example/capstonedesign1/global/dto/ResponseDto.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-@JsonPropertyOrder({"code", "message", "timestamp", "data"})
+@JsonPropertyOrder({"statusCode", "message", "timeStamp", "data"})
 public class ResponseDto<T> {
 
     private final String statusCode;

--- a/src/main/java/org/example/capstonedesign1/global/exception/AuthenticationException.java
+++ b/src/main/java/org/example/capstonedesign1/global/exception/AuthenticationException.java
@@ -1,0 +1,13 @@
+package org.example.capstonedesign1.global.exception;
+
+import org.example.capstonedesign1.global.exception.code.ErrorCode;
+
+public class AuthenticationException extends CustomException{
+    public AuthenticationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public AuthenticationException(ErrorCode errorCode, String detail) {
+        super(errorCode, detail);
+    }
+}

--- a/src/main/java/org/example/capstonedesign1/global/exception/AuthorizedException.java
+++ b/src/main/java/org/example/capstonedesign1/global/exception/AuthorizedException.java
@@ -1,0 +1,13 @@
+package org.example.capstonedesign1.global.exception;
+
+import org.example.capstonedesign1.global.exception.code.ErrorCode;
+
+public class AuthorizedException extends CustomException{
+    public AuthorizedException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public AuthorizedException(ErrorCode errorCode, String detail) {
+        super(errorCode, detail);
+    }
+}

--- a/src/main/java/org/example/capstonedesign1/global/exception/BadRequestException.java
+++ b/src/main/java/org/example/capstonedesign1/global/exception/BadRequestException.java
@@ -1,0 +1,13 @@
+package org.example.capstonedesign1.global.exception;
+
+import org.example.capstonedesign1.global.exception.code.ErrorCode;
+
+public class BadRequestException extends CustomException{
+    public BadRequestException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public BadRequestException(ErrorCode errorCode, String detail) {
+        super(errorCode, detail);
+    }
+}

--- a/src/main/java/org/example/capstonedesign1/global/exception/ConflictException.java
+++ b/src/main/java/org/example/capstonedesign1/global/exception/ConflictException.java
@@ -1,0 +1,15 @@
+package org.example.capstonedesign1.global.exception;
+
+import lombok.Getter;
+import org.example.capstonedesign1.global.exception.code.ErrorCode;
+
+@Getter
+public class ConflictException extends CustomException{
+    public ConflictException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public ConflictException(ErrorCode errorCode, String detail) {
+        super(errorCode, detail);
+    }
+}

--- a/src/main/java/org/example/capstonedesign1/global/exception/CustomException.java
+++ b/src/main/java/org/example/capstonedesign1/global/exception/CustomException.java
@@ -1,0 +1,20 @@
+package org.example.capstonedesign1.global.exception;
+
+import lombok.Getter;
+import org.example.capstonedesign1.global.exception.code.ErrorCode;
+
+@Getter
+public abstract class CustomException extends RuntimeException{
+    private final ErrorCode errorCode;
+    private final String detail;
+
+    protected CustomException(ErrorCode errorCode){
+        this.errorCode = errorCode;
+        this.detail = null;
+    }
+
+    protected CustomException(ErrorCode errorCode, String detail){
+        this.errorCode = errorCode;
+        this.detail = detail;
+    }
+}

--- a/src/main/java/org/example/capstonedesign1/global/exception/CustomException.java
+++ b/src/main/java/org/example/capstonedesign1/global/exception/CustomException.java
@@ -8,12 +8,12 @@ public abstract class CustomException extends RuntimeException{
     private final ErrorCode errorCode;
     private final String detail;
 
-    protected CustomException(ErrorCode errorCode){
+    public CustomException(ErrorCode errorCode){
         this.errorCode = errorCode;
         this.detail = null;
     }
 
-    protected CustomException(ErrorCode errorCode, String detail){
+    public CustomException(ErrorCode errorCode, String detail){
         this.errorCode = errorCode;
         this.detail = detail;
     }

--- a/src/main/java/org/example/capstonedesign1/global/exception/DtoValidationException.java
+++ b/src/main/java/org/example/capstonedesign1/global/exception/DtoValidationException.java
@@ -1,0 +1,14 @@
+package org.example.capstonedesign1.global.exception;
+
+import org.example.capstonedesign1.global.exception.code.ErrorCode;
+
+public class DtoValidationException extends CustomException{
+
+    public DtoValidationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public DtoValidationException(ErrorCode errorCode, String detail) {
+        super(errorCode, detail);
+    }
+}

--- a/src/main/java/org/example/capstonedesign1/global/exception/NotFoundException.java
+++ b/src/main/java/org/example/capstonedesign1/global/exception/NotFoundException.java
@@ -1,0 +1,13 @@
+package org.example.capstonedesign1.global.exception;
+
+import org.example.capstonedesign1.global.exception.code.ErrorCode;
+
+public class NotFoundException extends CustomException{
+    public NotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public NotFoundException(ErrorCode errorCode, String detail) {
+        super(errorCode, detail);
+    }
+}

--- a/src/main/java/org/example/capstonedesign1/global/exception/UnAuthenticationException.java
+++ b/src/main/java/org/example/capstonedesign1/global/exception/UnAuthenticationException.java
@@ -2,12 +2,12 @@ package org.example.capstonedesign1.global.exception;
 
 import org.example.capstonedesign1.global.exception.code.ErrorCode;
 
-public class AuthenticationException extends CustomException{
-    public AuthenticationException(ErrorCode errorCode) {
+public class UnAuthenticationException extends CustomException{
+    public UnAuthenticationException(ErrorCode errorCode) {
         super(errorCode);
     }
 
-    public AuthenticationException(ErrorCode errorCode, String detail) {
+    public UnAuthenticationException(ErrorCode errorCode, String detail) {
         super(errorCode, detail);
     }
 }

--- a/src/main/java/org/example/capstonedesign1/global/exception/code/ErrorCode.java
+++ b/src/main/java/org/example/capstonedesign1/global/exception/code/ErrorCode.java
@@ -14,6 +14,16 @@ public enum ErrorCode {
     LENGTH("4003", "길이가 유효하지 않습니다."),
     EMAIL("4004", "이메일 형식이 유효하지 않습니다."),
     NOT_NULL("4005", "필수값이 공백입니다."),
+    JSON_PARSE_ERROR("4006", "JSON 파싱 시 오류가 발생했습니다."),
+
+    USER_UNAUTHORIZED("4010", "로그인에 실패했습니다."),
+    EXPIRED_JWT_TOKEN("4011", "만료된 JWT 토큰입니다."),
+    INVALID_JWT_TOKEN("4012", "유효하지 않은 JWT 토큰입니다."),
+
+    USER_NOT_FOUND("4040", "유저를 찾을 수 없습니다."),
+
+    CONFLICT_EMAIL("4090", "중복된 이메일입니다."),
+    ALREADY_REGISTER_COMPLETED("4091", "이미 회원가입 완료한 유저입니다.")
     ;
 
     private final String status;

--- a/src/main/java/org/example/capstonedesign1/global/exception/code/ErrorCode.java
+++ b/src/main/java/org/example/capstonedesign1/global/exception/code/ErrorCode.java
@@ -1,0 +1,33 @@
+package org.example.capstonedesign1.global.exception.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    //BadRequest
+    SIZE("4001", "길이가 유효하지 않습니다."),
+    PATTERN("4001","형식에 맞지 않습니다."),
+    NOT_BLANK("4002", "필수값이 공백입니다."),
+    LENGTH("4003", "길이가 유효하지 않습니다."),
+    EMAIL("4004", "이메일 형식이 유효하지 않습니다."),
+    NOT_NULL("4005", "필수값이 공백입니다."),
+    ;
+
+    private final String status;
+    private final String message;
+
+    public static ErrorCode resolveValidationErrorCode(String code){
+        return switch (code){
+            case "Size" -> SIZE;
+            case "Pattern" -> PATTERN;
+            case "NotBlank" -> NOT_BLANK;
+            case "Length" -> LENGTH;
+            case "Email" -> EMAIL;
+            case "NotNull" -> NOT_NULL;
+            default -> throw new IllegalArgumentException("Unexpected value: "+ code);
+        };
+    }
+}

--- a/src/main/java/org/example/capstonedesign1/global/exception/controller/ExceptionController.java
+++ b/src/main/java/org/example/capstonedesign1/global/exception/controller/ExceptionController.java
@@ -3,6 +3,7 @@ package org.example.capstonedesign1.global.exception.controller;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.ValidationException;
 import lombok.extern.slf4j.Slf4j;
+import org.example.capstonedesign1.domain.auth.controller.AuthController;
 import org.example.capstonedesign1.global.dto.ErrorResponseDto;
 import org.example.capstonedesign1.global.exception.CustomException;
 import org.example.capstonedesign1.global.exception.DtoValidationException;
@@ -13,9 +14,10 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@RestControllerAdvice
+@RestControllerAdvice(annotations = {RestController.class}, basePackageClasses = {AuthController.class})
 @Slf4j
 public class ExceptionController {
 
@@ -66,7 +68,7 @@ public class ExceptionController {
     private void writeLog(Exception e){
         String nameOfException = e.getClass().getSimpleName();
         String messageOfException = e.getMessage();
-        log.error("[]: {}", nameOfException, messageOfException);
+        log.error("[{}]: {}", nameOfException, messageOfException);
     }
 
     private HttpStatus resolveHttpStatus(CustomException exception){

--- a/src/main/java/org/example/capstonedesign1/global/exception/controller/ExceptionController.java
+++ b/src/main/java/org/example/capstonedesign1/global/exception/controller/ExceptionController.java
@@ -1,0 +1,75 @@
+package org.example.capstonedesign1.global.exception.controller;
+
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.ValidationException;
+import lombok.extern.slf4j.Slf4j;
+import org.example.capstonedesign1.global.dto.ErrorResponseDto;
+import org.example.capstonedesign1.global.exception.CustomException;
+import org.example.capstonedesign1.global.exception.DtoValidationException;
+import org.example.capstonedesign1.global.exception.code.ErrorCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class ExceptionController {
+
+    @ExceptionHandler({CustomException.class})
+    protected ResponseEntity<ErrorResponseDto> handleCustomException(CustomException exception){
+        writeLog(exception);
+        HttpStatus httpStatus = resolveHttpStatus(exception);
+        return new ResponseEntity<>(ErrorResponseDto.res(exception), httpStatus);
+    }
+
+    @ExceptionHandler({MethodArgumentNotValidException.class})
+    protected ResponseEntity<ErrorResponseDto> handleCustomException(MethodArgumentNotValidException methodArgumentNotValidException){
+        FieldError fieldError = methodArgumentNotValidException.getBindingResult().getFieldError();
+        if(fieldError == null){
+            return new ResponseEntity<>(ErrorResponseDto.res(String.valueOf(HttpStatus.BAD_REQUEST.value()),
+                    methodArgumentNotValidException), HttpStatus.BAD_REQUEST);
+        }
+        ErrorCode validationErrorCode = ErrorCode.resolveValidationErrorCode(fieldError.getCode());
+        String detail = fieldError.getDefaultMessage();
+        DtoValidationException dtoValidationException = new DtoValidationException(validationErrorCode, detail);
+        writeLog(dtoValidationException);
+        return new ResponseEntity<>(ErrorResponseDto.res(dtoValidationException),HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    protected ResponseEntity<ErrorResponseDto> handleEntityNotFoundException(EntityNotFoundException entityNotFoundException){
+        writeLog(entityNotFoundException);
+        return new ResponseEntity<>(ErrorResponseDto.res(String.valueOf(HttpStatus.NOT_FOUND.value()),entityNotFoundException), HttpStatus.NOT_FOUND);
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponseDto> handleException(Exception e){
+        writeLog(e);
+        return new ResponseEntity<>(
+                ErrorResponseDto.res(String.valueOf(HttpStatus.INTERNAL_SERVER_ERROR.value()), e),
+                HttpStatus.INTERNAL_SERVER_ERROR
+        );
+    }
+
+    private void writeLog(CustomException customException){
+        String nameOfException = customException.getClass().getSimpleName();
+        String messageOfException = customException.getErrorCode().getMessage();
+        String detailOfException = customException.getDetail();
+        log.error("[{}]{}:{}", nameOfException, messageOfException, detailOfException);
+    }
+
+    private void writeLog(Exception e){
+        String nameOfException = e.getClass().getSimpleName();
+        String messageOfException = e.getMessage();
+        log.error("[]: {}", nameOfException, messageOfException);
+    }
+
+    private HttpStatus resolveHttpStatus(CustomException exception){
+        return HttpStatus.resolve(Integer.parseInt(exception.getErrorCode().getStatus().substring(0,3)));
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number
Closes #4 

## 📝 Description
- 회원가입 및 로그인 api 구현


## 🛠️ Change
- [x]  User 회원가입
  - 회원가입은 id, pw 로 진행하는 회원가입과 사용자 정보를 입력하는 회원가입 완료로 나뉨
- [x]  로그인 로직은 JwtLoginFilter에서 처리함  
- [x]  accessToken 인증 로직은 JwtAuthenticationFilter에서 처리함
- [x]  swagger에서 ControllerAdviceBean의 init 메서드가 존재하지 않는다는 에러가 발생하여 ControllerAdvice가 사용될 클래스를 명시하여 해결함. 이는 springBoot 버전 다운으로도 해결이 가능
