### PR TITLE
Feature/#12 카드 추천 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,10 @@ dependencies {
     //webflux - webclient
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+    // https://mvnrepository.com/artifact/org.apache.poi/poi
+    implementation 'org.apache.poi:poi:5.2.5'
+    implementation 'org.apache.poi:poi-ooxml:5.2.5'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/capstonedesign1/domain/bankproduct/entity/BankProduct.java
+++ b/src/main/java/org/example/capstonedesign1/domain/bankproduct/entity/BankProduct.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.example.capstonedesign1.domain.bankproduct.entity.enums.ProductType;
+import org.example.capstonedesign1.domain.bankproduct.entity.enums.BankProductType;
 import org.example.capstonedesign1.global.common.BaseEntity;
 
 import java.util.ArrayList;
@@ -21,7 +21,7 @@ public class BankProduct extends BaseEntity {
     @Column(nullable = false)
     private String name;
     @Enumerated(EnumType.STRING)
-    private ProductType productType;
+    private BankProductType bankProductType;
     @Column(nullable = false)
     private String bankName;
     private String description;
@@ -45,7 +45,7 @@ public class BankProduct extends BaseEntity {
         StringBuilder sb = new StringBuilder("BankProduct{");
         sb.append("id=").append(this.getId())
                 .append(", name=").append(name)
-                .append(", productType=").append(productType)
+                .append(", productType=").append(bankProductType)
                 .append(", bankName=").append(bankName)
                 .append(", description=").append(description != null ? description : "없음");
 

--- a/src/main/java/org/example/capstonedesign1/domain/bankproduct/entity/enums/BankProductType.java
+++ b/src/main/java/org/example/capstonedesign1/domain/bankproduct/entity/enums/BankProductType.java
@@ -1,5 +1,5 @@
 package org.example.capstonedesign1.domain.bankproduct.entity.enums;
 
-public enum ProductType {
+public enum BankProductType {
     DEPOSIT, SAVING
 }

--- a/src/main/java/org/example/capstonedesign1/domain/cardproduct/controller/CardProductController.java
+++ b/src/main/java/org/example/capstonedesign1/domain/cardproduct/controller/CardProductController.java
@@ -1,0 +1,41 @@
+package org.example.capstonedesign1.domain.cardproduct.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.example.capstonedesign1.domain.auth.security.CustomUserDetails;
+import org.example.capstonedesign1.domain.cardproduct.dto.response.CardProductRecommendationResponse;
+import org.example.capstonedesign1.domain.cardproduct.service.CardProductCommandService;
+import org.example.capstonedesign1.global.dto.ResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/card-product")
+public class CardProductController {
+
+    private final CardProductCommandService cardProductCommandService;
+
+    @Operation(
+            summary = "카드 상품 추천 API",
+            description = "입력받은 결제 내역, 그리고 유저의 상세 정보를 사용하여 카드 상품을 추천받는 api"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "금융 상품 추천 받기 성공"),
+            @ApiResponse(responseCode = "4007", description = "아직 금융 성향 분석을 진행하지 않은 경우"),
+            @ApiResponse(responseCode = "5000", description = "서버 내부에서 json 파싱 오류")
+    })
+    @PostMapping(value = "/recommend", consumes = MediaType.MULTIPART_FORM_DATA_VALUE )
+    public ResponseEntity<ResponseDto<CardProductRecommendationResponse>> getUserPropensity(
+            @RequestPart MultipartFile file,
+            @AuthenticationPrincipal CustomUserDetails userDetails){
+        CardProductRecommendationResponse response = cardProductCommandService.recommendCardProduct(userDetails.getUser(), file);
+        return new ResponseEntity<>(ResponseDto.res(HttpStatus.OK, "카드 상품 추천 받기 성공", response), HttpStatus.OK);
+    }
+}

--- a/src/main/java/org/example/capstonedesign1/domain/cardproduct/dto/json/CardProductRecommendationContent.java
+++ b/src/main/java/org/example/capstonedesign1/domain/cardproduct/dto/json/CardProductRecommendationContent.java
@@ -1,0 +1,16 @@
+package org.example.capstonedesign1.domain.cardproduct.dto.json;
+
+import org.example.capstonedesign1.domain.bankproduct.dto.json.BankProductRecommendationContent;
+
+import java.util.List;
+
+public record CardProductRecommendationContent(
+        List<BankProductRecommendationContent.RecommendedProductContent> recommendations,
+        String strategy) {
+
+    public record RecommendedProductContent (String id,
+                                             String description,
+                                             String reason,
+                                             String detailUrl) {
+    }
+}

--- a/src/main/java/org/example/capstonedesign1/domain/cardproduct/dto/response/CardProductRecommendationResponse.java
+++ b/src/main/java/org/example/capstonedesign1/domain/cardproduct/dto/response/CardProductRecommendationResponse.java
@@ -1,0 +1,12 @@
+package org.example.capstonedesign1.domain.cardproduct.dto.response;
+
+import org.example.capstonedesign1.domain.cardproduct.dto.json.CardProductRecommendationContent;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record CardProductRecommendationResponse (UUID id,
+                                                 CardProductRecommendationContent content,
+                                                 LocalDateTime createdAt){
+
+}

--- a/src/main/java/org/example/capstonedesign1/domain/cardproduct/entity/CardProduct.java
+++ b/src/main/java/org/example/capstonedesign1/domain/cardproduct/entity/CardProduct.java
@@ -1,0 +1,43 @@
+package org.example.capstonedesign1.domain.cardproduct.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.Getter;
+import org.example.capstonedesign1.domain.cardproduct.entity.enums.CardProductType;
+import org.example.capstonedesign1.global.common.BaseEntity;
+
+@Entity
+@Getter
+public class CardProduct extends BaseEntity {
+
+    @Column(nullable = false)
+    private String name;
+    @Enumerated(EnumType.STRING)
+    private CardProductType cardProductType;
+    @Column(nullable = false)
+    private String bankName;
+
+    private String description;
+    private Integer annualFee;
+    @Column(length = 1000)
+    private String benefit;
+    private String detailUrl;
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("CardProduct{");
+        sb.append("id=" + this.getId())
+                .append(", name=" + name)
+                .append(", type=" + cardProductType)
+                .append(", bankName=" + bankName);
+
+        sb.append(this.description != null ? ", description=" + description : "")
+                .append(", annualFee=").append(this.annualFee != null ? annualFee : 0)
+                .append(this.benefit != null ?  ", benefit=" + benefit : "")
+                .append(this.detailUrl != null ?  ", detailUrl=" + detailUrl : "");
+
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/example/capstonedesign1/domain/cardproduct/entity/CardProductPropensity.java
+++ b/src/main/java/org/example/capstonedesign1/domain/cardproduct/entity/CardProductPropensity.java
@@ -1,0 +1,16 @@
+package org.example.capstonedesign1.domain.cardproduct.entity;
+
+import jakarta.persistence.*;
+import org.example.capstonedesign1.domain.propensity.entity.enums.Propensity;
+import org.example.capstonedesign1.global.common.BaseEntity;
+
+@Entity
+public class CardProductPropensity extends BaseEntity {
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Propensity propensity;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "card_product_id", nullable = false)
+    private CardProduct cardProduct;
+}

--- a/src/main/java/org/example/capstonedesign1/domain/cardproduct/entity/CardProductRecommendation.java
+++ b/src/main/java/org/example/capstonedesign1/domain/cardproduct/entity/CardProductRecommendation.java
@@ -1,0 +1,22 @@
+package org.example.capstonedesign1.domain.cardproduct.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.capstonedesign1.domain.user.entity.User;
+import org.example.capstonedesign1.global.common.BaseEntity;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CardProductRecommendation extends BaseEntity {
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    User user;
+
+    @Column(nullable = false, columnDefinition = "JSON")
+    String content;
+}

--- a/src/main/java/org/example/capstonedesign1/domain/cardproduct/entity/enums/CardProductType.java
+++ b/src/main/java/org/example/capstonedesign1/domain/cardproduct/entity/enums/CardProductType.java
@@ -1,0 +1,5 @@
+package org.example.capstonedesign1.domain.cardproduct.entity.enums;
+
+public enum CardProductType {
+    CREDIT, CHECK
+}

--- a/src/main/java/org/example/capstonedesign1/domain/cardproduct/repository/CardProductRecommendationRepository.java
+++ b/src/main/java/org/example/capstonedesign1/domain/cardproduct/repository/CardProductRecommendationRepository.java
@@ -1,0 +1,9 @@
+package org.example.capstonedesign1.domain.cardproduct.repository;
+
+import org.example.capstonedesign1.domain.cardproduct.entity.CardProductRecommendation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface CardProductRecommendationRepository extends JpaRepository<CardProductRecommendation, UUID> {
+}

--- a/src/main/java/org/example/capstonedesign1/domain/cardproduct/repository/CardProductRepository.java
+++ b/src/main/java/org/example/capstonedesign1/domain/cardproduct/repository/CardProductRepository.java
@@ -1,0 +1,20 @@
+package org.example.capstonedesign1.domain.cardproduct.repository;
+
+import org.example.capstonedesign1.domain.cardproduct.entity.CardProduct;
+import org.example.capstonedesign1.domain.propensity.entity.enums.Propensity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface CardProductRepository extends JpaRepository<CardProduct, UUID> {
+
+    @Query("select cp " +
+            "from CardProduct cp " +
+            "inner join CardProductPropensity cpp on cpp.cardProduct = cp and cpp.propensity = :propensity")
+    List<CardProduct> getRecommendable(@Param("propensity") Propensity propensity);
+}

--- a/src/main/java/org/example/capstonedesign1/domain/cardproduct/service/CardProductCommandService.java
+++ b/src/main/java/org/example/capstonedesign1/domain/cardproduct/service/CardProductCommandService.java
@@ -1,0 +1,142 @@
+package org.example.capstonedesign1.domain.cardproduct.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.apache.poi.poifs.crypt.Decryptor;
+import org.apache.poi.poifs.crypt.EncryptionInfo;
+import org.apache.poi.poifs.filesystem.POIFSFileSystem;
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.example.capstonedesign1.domain.bankproduct.dto.request.BankProductRecommendRequest;
+import org.example.capstonedesign1.domain.cardproduct.entity.CardProduct;
+import org.example.capstonedesign1.domain.cardproduct.repository.CardProductRepository;
+import org.example.capstonedesign1.domain.chat.client.OpenAiApiClient;
+import org.example.capstonedesign1.domain.propensity.entity.enums.Propensity;
+import org.example.capstonedesign1.domain.user.entity.User;
+import org.example.capstonedesign1.domain.user.service.UserQueryService;
+import org.example.capstonedesign1.global.exception.AuthorizedException;
+import org.example.capstonedesign1.global.exception.BadRequestException;
+import org.example.capstonedesign1.global.exception.code.ErrorCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.GeneralSecurityException;
+import java.util.List;
+
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class CardProductCommandService {
+    private static final int MAX_ROW = 100;
+    private static final int START_ROW = 9;
+    private static final String DELIMITER = ", ";
+
+    private final UserQueryService userQueryService;
+
+    private final CardProductRepository cardProductRepository;
+
+    private final OpenAiApiClient openAiApiClient;
+
+    public void recommendCardProduct(User user, MultipartFile file){
+        validXlsxFile(file);
+        String paymentRecord = resolvePaymentRecord(user, file); //비동기로 처리하면 더 빠를 것 같음.
+
+        Propensity userPropensity = userQueryService.ensureUserPropensity(user);
+        List<CardProduct> cardProducts = cardProductRepository.getRecommendable(userPropensity);
+
+        StringBuilder sb = new StringBuilder();
+
+        cardProducts.stream()
+                .map(CardProduct::toString)
+                .forEach(sb::append);
+
+        log.info(sb);
+
+    }
+
+    private void validXlsxFile(MultipartFile file){
+        if(file.isEmpty()
+                || !file.getOriginalFilename().toLowerCase().endsWith(".xlsx")){
+            throw new BadRequestException(ErrorCode.INVALID_FILE);
+        }
+    }
+
+
+    private String resolvePaymentRecord(User user, MultipartFile file){
+        //try with resource
+        try(InputStream inputStream = file.getInputStream()){
+            POIFSFileSystem fs = new POIFSFileSystem(inputStream);
+            EncryptionInfo info = new EncryptionInfo(fs);
+            Decryptor decryptor = Decryptor.getInstance(info);
+
+            if(decryptor.verifyPassword(user.get6DigitBirthDate())){
+                try (InputStream decryptedStream = decryptor.getDataStream(fs);
+                     Workbook workbook = new XSSFWorkbook(decryptedStream)) {
+                    Sheet sheet = workbook.getSheetAt(0); // 첫 번째 시트 읽기
+                    return paymentRecordFormat(sheet);
+                }
+            }
+            throw new AuthorizedException(ErrorCode.PAYMENT_XLSX_UNAUTHORIZED);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } catch (GeneralSecurityException e) {
+            throw new AuthorizedException(ErrorCode.PAYMENT_XLSX_UNAUTHORIZED, "결제 내역 파일의 PW가 일치하지 않습니다.");
+        }
+    }
+    
+    private String paymentRecordFormat(Sheet sheet){
+        StringBuilder sb = new StringBuilder();
+
+        int maxRow = Math.min(MAX_ROW, sheet.getLastRowNum());
+        for (int i=START_ROW; i<maxRow; i++){ // START_ROW 이전에는 필요없는 정보들이므로 제외
+            Row row = sheet.getRow(i);
+            if (row == null) {
+                continue;
+            }
+            for(int j=0 ; j<row.getLastCellNum() - 1;j++) { // 거래 후 잔액은 제외하기 위해서 -1을 함
+                Cell cell = row.getCell(j);
+                if (cell == null) {
+                    continue;
+                } else if (j == 1) {
+                    sb.append(parseTFromDTColumn(cell.getStringCellValue()));
+                } else {
+                    sb.append(getValueFromCell(cell));
+                }
+                sb.append(DELIMITER);
+            }
+            sb.append("\n");
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * DateTime 에서 날짜, 시간만 추출하여 반환. 년도, 초 등은 제외
+     * @param cell
+     * @return
+     */
+    private String parseTFromDTColumn(String cell){
+        if(cell.length() > 16){
+            return cell.substring(5, 16);
+        }
+        return cell;
+    }
+
+    private String getValueFromCell(Cell cell){
+        switch (cell.getCellType()) {
+            case STRING:
+                return cell.getStringCellValue();
+            case NUMERIC:
+                return String.valueOf((long) cell.getNumericCellValue());
+            case BOOLEAN:
+                return String.valueOf(cell.getBooleanCellValue());
+            default:
+                return "N/A";
+        }
+    }
+
+
+}

--- a/src/main/java/org/example/capstonedesign1/domain/propensity/repository/PropensityQuestionRepository.java
+++ b/src/main/java/org/example/capstonedesign1/domain/propensity/repository/PropensityQuestionRepository.java
@@ -1,18 +1,12 @@
 package org.example.capstonedesign1.domain.propensity.repository;
 
-import org.example.capstonedesign1.domain.propensity.dto.response.SurveyItemResponse;
 import org.example.capstonedesign1.domain.propensity.entity.PropensityQuestion;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
-
-//select q.content, a.content
-//from PropensityQuestion as q
-//        join PropensityQuestionOption as a on q.id = a.propensity_question_id
 
 
 @Repository

--- a/src/main/java/org/example/capstonedesign1/domain/user/entity/User.java
+++ b/src/main/java/org/example/capstonedesign1/domain/user/entity/User.java
@@ -6,6 +6,8 @@ import org.example.capstonedesign1.domain.propensity.entity.enums.Propensity;
 import org.example.capstonedesign1.domain.user.entity.enums.Role;
 import org.example.capstonedesign1.global.common.BaseEntity;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -41,6 +43,11 @@ public class User extends BaseEntity {
 
     public void updatePropensity(Propensity propensity){
         this.profile.updatePropensity(propensity);
+    }
+
+    public String get6DigitBirthDate(){
+        LocalDate birthDate = this.profile.getBirthDate();
+        return birthDate.format(DateTimeFormatter.ofPattern("yyMMdd"));
     }
 
     @Override

--- a/src/main/java/org/example/capstonedesign1/global/exception/code/ErrorCode.java
+++ b/src/main/java/org/example/capstonedesign1/global/exception/code/ErrorCode.java
@@ -16,12 +16,14 @@ public enum ErrorCode {
     NOT_NULL("4005", "필수값이 공백입니다."),
     INVALID_JSON_REQUEST("4006", "JSON 파싱 시 오류가 발생했습니다."),
     PROPENSITY_NOT_SET("4007", "아직 금융 성향 분석을 진행하지 않은 유저입니다."),
+    INVALID_FILE("4008", "잘못된 파일 형식입니다."),
 
     USER_UNAUTHORIZED("4010", "로그인에 실패했습니다."),
     EXPIRED_JWT_TOKEN("4011", "만료된 JWT 토큰입니다."),
     INVALID_JWT_TOKEN("4012", "유효하지 않은 JWT 토큰입니다."),
 
     UN_AUTHORIZED("4030", "접근 권한이 없습니다."),
+    PAYMENT_XLSX_UNAUTHORIZED("4031", "결제 내역 파일에 접근할 수 없습니다."),
 
     USER_NOT_FOUND("4040", "유저를 찾을 수 없습니다."),
     USER_PROPENSITY_NOT_FOUND("4041", "금융 성향 분석을 찾을 수 없습니다."),

--- a/src/main/java/org/example/capstonedesign1/global/template/PromptTemplate.java
+++ b/src/main/java/org/example/capstonedesign1/global/template/PromptTemplate.java
@@ -2,6 +2,7 @@ package org.example.capstonedesign1.global.template;
 
 import org.example.capstonedesign1.domain.bankproduct.dto.request.BankProductRecommendRequest;
 import org.example.capstonedesign1.domain.bankproduct.entity.BankProduct;
+import org.example.capstonedesign1.domain.cardproduct.entity.CardProduct;
 import org.example.capstonedesign1.domain.propensity.dto.request.SurveyRequest;
 import org.example.capstonedesign1.domain.user.entity.Profile;
 import org.example.capstonedesign1.domain.user.entity.User;
@@ -114,6 +115,56 @@ public class PromptTemplate {
                     }
                   ],
                   "strategy": "<금융 상품 추천 이유 및 전략 설명>"
+                }
+                """
+        );
+    }
+
+    public static String CardProductRecommendPrompt(User user, String paymentRecord, List<CardProduct> products){
+        Profile profile = user.getProfile();
+        StringBuilder stringBuilder = new StringBuilder();
+        products.stream()
+                .forEach(product -> stringBuilder.append(product.toString()).append("\n\n"));
+        return fillTemplate(
+                """
+                ## 명령
+                사용자의 최근 결제 내역을 중심으로, 금융 성향 + 정보를 고려하여 카드 상품을 추천해줘.
+                카드 상품 목록은 DB 내의 사용자 금융 성향과 일치하는 상품들을 분류해놓은 거야.
+                결과는 JSON 형식으로 반환해줘. 결과에서 recommendations 목록은 1 ~ 3개까지 넣어줘
+
+                ## 사용자 정보
+                금융 성향: %s
+                성별: %s
+                만 나이: %s
+                월 수입: %s
+                자산: %s
+                
+                ## 사용자의 최근 결제 내역
+                %s
+                
+                ## 카드 상품 목록
+                %s
+
+                """.formatted(
+                        profile.getPropensity().getName(),
+                        profile.getGender(),
+                        Period.between(profile.getBirthDate(), LocalDate.now()),
+                        profile.getSalary(),
+                        profile.getAsset(),
+                        paymentRecord,
+                        stringBuilder
+                ),
+                """
+                {
+                  "recommendations": [
+                    {
+                      "id": "<카드 상품 ID>",
+                      "description": "<카드 상품 설명>",
+                      "reason": "<추천 이유 및 장단점>",
+                      "detailUrl": "<상세 URL>"
+                    }
+                  ],
+                  "strategy": "<종합적인 상품 추천 이유 및 전략 설명>"
                 }
                 """
         );


### PR DESCRIPTION
## #️⃣ Issue Number
Closes #12

## 📝 Description
- 사용자의 결제 내역과 금융 성향, 자산 등을 기반으로 카드 상품을 추천받는 api 구현

## 🛠️ Change
- [x] 카드 상품 관련 엔티티 작성
- [x] 카드 결제 내역 csv(xlsx) 파일을 json으로 변환 
- [x] 카드 결제 내역 및 사용자 요구사항을 바탕으로 카드 추천 기능 구현 

- 추가적으로 현재 추천 내역의 테이블에 대해 반졍형(json)과 정형 둘 중 어느 것을 고를지 트레이드 오프를 고민 중에 있음.
  - json으로 저장할 경우 column 명을 테이블의 content 내에 함께 저장하므로 불필요하게 용량이 커지는 문제가 발생. 구조적으로도 추후 특정 필드를 사용해야 한다면(가능성 낮음),,, 문제가 발생할 수 있음.
  
  - 정규화를 할 경우 카드 상품 추천, 금융 상품 추천을 함께 반환하고 싶은 경우  json으로 저장할 때는 이게 가능했지만 불가능해짐. (현재는 요구되지 않지만 추후 변하기 쉬운 부분이라고 판단됨).
  또한 각 추천에는 DB 내에 저장되어있는 상품들이 1~3개 정도 들어감. 만약 정규화를 한다면 이것도 테이블을 나눠서, 상품 추천 결과 테이블과 상품 사이에 액션 테이블이 생기는 소요가 있을 것 같음.... 그런데 이렇게 되면 정규화로 인해 불필요한 조인이 늘어날 것으로 우려됨.
